### PR TITLE
Store User's Choices During Patch Creation to Prevent Repeated Config…

### DIFF
--- a/lib/creation.py
+++ b/lib/creation.py
@@ -3,6 +3,7 @@ from os.path import join as path_join
 from os.path import relpath
 
 from lib.config import PatcherConfig
+from lib.creation_config import PatchCreationConfig
 from lib.patch import Patch, PatchFile, load_patches
 from lib.ui.console import ConsoleUserInterface
 
@@ -19,7 +20,7 @@ def _scan_for_configs_(configs_folder: str) -> list[str]:
 
     return configs
 
-def create_patch_file(configs_folder: str, config: PatcherConfig, cui: ConsoleUserInterface):
+def create_patch_file(configs_folder: str, config: PatcherConfig, cui: ConsoleUserInterface, pcc: PatchCreationConfig):
     patches = load_patches(config)
     patch_version = list(sorted(patches.keys()))[-1] + 1 if len(patches) > 0 else 0
 
@@ -43,8 +44,7 @@ def create_patch_file(configs_folder: str, config: PatcherConfig, cui: ConsoleUs
 
     for config_path, old_patches in old_patches_map.items():
         rel_config_path = relpath(config_path, configs_folder)
-
-        patch = Patch.new_patch(config_path=config_path, old_patches=old_patches, rel_path=rel_config_path, cui=cui)
+        patch = Patch.new_patch(config_path=config_path, old_patches=old_patches, rel_path=rel_config_path, cui=cui, pcc=pcc)
         if patch is not None:
             new_patches[rel_config_path] = patch
 

--- a/lib/creation_config.py
+++ b/lib/creation_config.py
@@ -1,0 +1,95 @@
+from collections import namedtuple
+from functools import lru_cache
+from os.path import join as path_join, isdir, isfile
+from os import makedirs
+from typing import Any, NamedTuple, Optional, Tuple
+from json import load as json_load, dump as json_dump
+
+from Typing import SCRIPT_ROOT
+from lib.ui.items import Direction
+
+ModName = str
+FlatKey = str
+ModPatchValue = NamedTuple('ModPatchValue', [('direction', Direction), ('value', Any)])
+ModPatchSettings = dict[FlatKey, ModPatchValue]
+PatchSettings = dict[ModName, ModPatchSettings]
+
+
+class PatchCreationConfig():
+    _CONFIG_FOLDER_NAME = 'create_configs'
+    _EXTENSION = '.cc'
+
+    _settings: PatchSettings
+    _config_folder_name: Optional[str]
+
+    def __init__(self, config_folder_name: Optional[str], settings: Optional[dict[str, dict]] = None):
+        self._settings = settings if settings else {}
+        self._config_folder_name = config_folder_name
+
+    @lru_cache
+    @classmethod
+    def _get_config_folder_(cls) -> str:
+        return path_join(SCRIPT_ROOT, cls._CONFIG_FOLDER_NAME)
+
+    @classmethod
+    def _create_filepath_(cls, config_folder_name: str) -> str:
+        return path_join(cls._get_config_folder_(), f"{config_folder_name}{cls._EXTENSION}")
+    
+    @classmethod
+    def read(cls, config_folder_name: str) -> 'PatchCreationConfig':
+        settings: Optional[dict] = None
+        path = cls._create_filepath_(config_folder_name)
+
+        if isfile(path):
+            with open(path, 'r') as f:
+                settings = json_load(f)
+
+            assert isinstance(settings, dict)
+            for mod, d in settings.items():
+                assert isinstance(mod, str)
+                assert isinstance(d, dict)
+
+                for key in d.keys():
+                    assert isinstance(key, str)
+        
+        return PatchCreationConfig(config_folder_name, settings)
+    
+    def write(self) -> None:
+        if self._config_folder_name is None:
+            return
+        
+        path = self._create_filepath_(self._config_folder_name)
+        folder_path = self._get_config_folder_()
+
+        if not isdir(folder_path):
+            makedirs(folder_path)
+
+        with open(path, 'w') as f:
+            json_dump(self._settings, f, indent=None)
+
+    def get_creation_state(self, mod_config_path: str, config_data: dict[str, Any]) -> dict[str, Direction]:
+        mod_settings = self._settings.get(mod_config_path, None)
+        if mod_settings is None:
+            return dict()
+        
+        res: dict[str, Direction] = {}
+        for key, c_value in config_data.items():
+            if (key in mod_settings) and (m_value := mod_settings[key]) != c_value:
+                mod_settings[key] = m_value
+
+        return res
+
+    def _create_mod_settings_(self, patched_config: dict[str, Any], user_choice: dict[str, Direction]):
+        patched_keys = set(patched_config.keys())
+        keys = patched_keys.intersection(user_choice.keys())
+        assert keys == patched_keys
+
+        return {
+            k : ModPatchValue(direction=user_choice[k], value=patched_config[k])
+            for k
+            in patched_config
+        }
+    
+    def add_mod_settings(self, mod_config_path: str, on_disk_flattend: dict[str, Any], user_choice: dict[str, Direction]):
+        settings = self._create_mod_settings_(on_disk_flattend, user_choice)
+        self._settings[mod_config_path] = settings

--- a/lib/patch.py
+++ b/lib/patch.py
@@ -12,6 +12,7 @@ from re import compile as regex_compile
 from typing import Any, Tuple
 
 from lib.config import PatcherConfig
+from lib.creation_config import PatchCreationConfig
 from lib.ui.console import ConsoleUserInterface
 
 PATCH_FOLDER_NAME = 'Patches'
@@ -100,7 +101,7 @@ class Patch():
         )
 
     @classmethod
-    def new_patch(cls, config_path: str, old_patches: list['Patch'], rel_path: str, cui: ConsoleUserInterface) -> 'Patch | None':
+    def new_patch(cls, config_path: str, old_patches: list['Patch'], rel_path: str, cui: ConsoleUserInterface, pcc: PatchCreationConfig) -> 'Patch | None':
         patched_config = {}
 
         for patch in old_patches:
@@ -112,7 +113,7 @@ class Patch():
         with open(config_path, 'r') as f:
             on_disk_config = json_load(f)
 
-        create_on_missing, overwrite, remove = cui.compare(rel_path, on_disk=on_disk_config, patch=patched_config)
+        create_on_missing, overwrite, remove = cui.compare(rel_path, on_disk=on_disk_config, patch=patched_config, pcc=pcc)
 
         if len(create_on_missing) == 0 and len(overwrite) == 0 and len(remove) == 0:
             return None

--- a/lib/ui/items.py
+++ b/lib/ui/items.py
@@ -86,11 +86,21 @@ class DirectionSelectionItem(OptionalOptionItem):
     _NOT_SET_CHAR = 'Ignore'
     _FALSE_CHAR = 'Patch'
     _key: str
+    _new: bool
 
-    def __init__(self, key: str, on_disk_value: str, patch_value: str, default_value: Direction = Direction.IGNORE, menu: ConsoleMenu | None = None, menu_char: str | None = None) -> None:
-        super().__init__(f'{key}:\nConfig Value: {on_disk_value}\nPatch Value: {patch_value}', menu=menu, should_exit=False, menu_char=menu_char)
+    def __init__(self, key: str, on_disk_value: str, patch_value: str, default_value: Direction = Direction.IGNORE, menu: ConsoleMenu | None = None, menu_char: str | None = None, new_value: bool = True) -> None:
+        super().__init__(f'{key}:\n\t-Config Value: {on_disk_value}\n\t-Patch Value: {patch_value}', menu=menu, should_exit=False, menu_char=menu_char)
         self._key = key
         self._value = default_value.value
+        self._new = new_value
+
+    def get_checkbox(self) -> str:
+        chkbox = super().get_checkbox()
+
+        if self._new:
+            chkbox = "* %s" % chkbox
+
+        return chkbox
 
     def get_return(self) -> Direction:
         return Direction.from_value(self._value)


### PR DESCRIPTION
…urations #5

- Stores previous user choice and the last config value
- If last config value is different from current adds an * infront of checkbox
- Automatically stores user choice
- Currently user choice is not saved on disk
- Maybe readability improved of options